### PR TITLE
Fix initial value of front camera enabled to true

### DIFF
--- a/app/src/main/kotlin/d/d/meshenger/SettingsActivity.kt
+++ b/app/src/main/kotlin/d/d/meshenger/SettingsActivity.kt
@@ -598,6 +598,11 @@ class SettingsActivity : BaseActivity(), ServiceConnection {
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             var check = 0
             override fun onItemSelected(parent: AdapterView<*>?, view: View, pos: Int, id: Long) {
+                if (pos >= arrayValues.size) {
+                    Toast.makeText(this@SettingsActivity,
+                        "pos out of bounds: $arrayValues", Toast.LENGTH_SHORT).show()
+                    return
+                }
                 if (check++ > 0) {
                     callback.call(arrayValues[pos])
                 }

--- a/app/src/main/kotlin/d/d/meshenger/call/RTCCall.kt
+++ b/app/src/main/kotlin/d/d/meshenger/call/RTCCall.kt
@@ -39,7 +39,7 @@ class RTCCall : RTCPeerConnection {
 
     private var isCameraEnabled = false
     private var isMicrophoneEnabled = false
-    private var useFrontFacingCamera = false
+    private var useFrontFacingCamera = true
 
     fun getMicrophoneEnabled(): Boolean {
         return isMicrophoneEnabled

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -89,6 +89,9 @@
 
     <string-array name="cameraFramerateValues">
         <item>auto</item>
+        <item>60</item>
+        <item>50</item>
+        <item>40</item>
         <item>30</item>
         <item>20</item>
         <item>15</item>


### PR DESCRIPTION
 The code assumes that the front camera is in use.
 If the settings don't match, then we perform a switch.

 As such, this should be initialized to true.
 If not, the user setting to frontCamera false, will not work