### PR TITLE
Expand foreground service capabilities to include microphone and camera

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
 
     <!-- Run server socket as foreground service. As such we must display a notification (sdk-28) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Allow to start activity from background -->
@@ -56,7 +58,8 @@
         <service
             android:name=".MainService"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback" />
+            android:foregroundServiceType="mediaPlayback|microphone|camera"
+             />
 
         <activity
             android:name=".StartActivity"

--- a/app/src/main/kotlin/d/d/meshenger/MainService.kt
+++ b/app/src/main/kotlin/d/d/meshenger/MainService.kt
@@ -8,6 +8,8 @@ package d.d.meshenger
 import android.app.*
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
 import android.graphics.Color
 import android.os.Binder
@@ -192,7 +194,7 @@ class MainService : Service(), Runnable {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
                 startForeground(NOTIFICATION_ID, notification)
             } else {
-                startForeground(NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+                startForeground(NOTIFICATION_ID, notification, FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK or FOREGROUND_SERVICE_TYPE_MICROPHONE or FOREGROUND_SERVICE_TYPE_CAMERA)
             }
         } else if (intent.action == STOP_FOREGROUND_ACTION) {
             Log.d(this, "onStartCommand() Received Stop Foreground Intent")


### PR DESCRIPTION
- Added FOREGROUND_SERVICE_MICROPHONE and FOREGROUND_SERVICE_CAMERA permissions in AndroidManifest.xml
- Updated MainService to request all required foreground service types (mediaPlayback, microphone, camera) on Android 13+